### PR TITLE
Added pre-flight check for port 8888 conflicts

### DIFF
--- a/blockchain/scripts/continue_blockchain.sh
+++ b/blockchain/scripts/continue_blockchain.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
-set -o errexit
 
 # this file is used to continue the stopped blockchain
+
+# Check for port conflicts
+curl --output /dev/null \
+    --silent \
+    --head \
+    --fail \
+    localhost:8888
+
+retval=$?
+if [ $retval == 0 ]; then
+    echo "You have a process already using port 8888, which is preventing nodeos from starting"
+    exit 1
+fi
+
+set -o errexit
 
 echo "=== continuing existing blockchain ==="
 

--- a/blockchain/scripts/init_blockchain.sh
+++ b/blockchain/scripts/init_blockchain.sh
@@ -1,6 +1,18 @@
 # Make Data Directory
 mkdir -p "$(pwd)/blockchain/data"
 
+curl --output /dev/null \
+    --silent \
+    --head \
+    --fail \
+    localhost:8888
+
+retval=$?
+if [ $retval == 0 ]; then
+    echo "You have a process already using port 8888, which is preventing nodeos from starting"
+    exit 1
+fi
+
 # Start Nodeos
 nodeos -e -p eosio -d "$(pwd)/blockchain/data" \
     --config-dir "$(pwd)/blockchain/data/config" \


### PR DESCRIPTION
I ran into a few students that had Jupyter notebooks running on their machine, which was already using port 8888. Since nodeos is configured to use port 8888 (and I'm not sure what else may be expecting that port number), I just did a preflight check. If it makes more sense to simply change the port, that would be fine to me!

I also played around with finding a way to display "Here's the process currently using that port", but making that work cross-platform proved tricky. So, feel free to iterate on if you want too.