### PR TITLE
Add version discovery to ubuntu installation

### DIFF
--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -17,8 +17,11 @@ apt install -y nodejs
 UBUNTU_VERSION=$(lsb_release --release | cut -f2)
 if [ "18.04" -eq "$UBUNTU_VERSION" ]; then
   EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-18.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")
-else
+elif [ "16.04" -eq "$UBUNTU_VERSION" ]; then
   EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-16.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")
+else
+  printf "\n\tEosio binaries are only available for Ubuntu 16.04 and 18.04.\n\n"
+  exit -1
 fi
 
 EOSIO_FILENAME=$(echo $EOSIO_DOWNLOAD_URL | sed 's:.*/::')

--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -4,7 +4,7 @@
 if [ "$(id -u)" -ne 0 ]; then
         printf "\n\tThis requires sudo. Please run with sudo.\n\n"
         exit -1
-fi 
+fi
 
 # Install Dependencies
 apt install -y curl sed
@@ -14,7 +14,13 @@ curl -sL https://deb.nodesource.com/setup_10.x | bash -
 apt install -y nodejs
 
 # Get Binary Packages Information
-EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-18.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")
+UBUNTU_VERSION=$(lsb_release --release | cut -f2)
+if [ $UBUNTU_VERSION="18.04" ]; then
+  EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-18.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")
+else
+  EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-16.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")
+fi
+
 EOSIO_FILENAME=$(echo $EOSIO_DOWNLOAD_URL | sed 's:.*/::')
 
 CDT_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eosio.cdt/releases/latest" | grep "browser_download_url.*amd64.deb" | cut -d ":" -f 2,3 | tr -d \")

--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -15,7 +15,7 @@ apt install -y nodejs
 
 # Get Binary Packages Information
 UBUNTU_VERSION=$(lsb_release --release | cut -f2)
-if [ $UBUNTU_VERSION="18.04" ]; then
+if [ "18.04" -eq "$UBUNTU_VERSION" ]; then
   EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-18.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")
 else
   EOSIO_DOWNLOAD_URL=$(curl --silent "https://api.github.com/repos/EOSIO/eos/releases/latest" | grep "browser_download_url.*ubuntu-16.04_amd64.deb" | cut -d ":" -f 2,3 | tr -d \")


### PR DESCRIPTION
Presently, the ubuntu installation script assumes the developer has Ubuntu 18.04. The 18.04 eosio binary will not run on Ubuntu 16.04. 

- checks Ubuntu version with `lsb_release`
- downloads the correct binary for the ubuntu version.
- exits if version of ubuntu -ne 16.04 || 18.04 

Resolves #5 